### PR TITLE
Close open screen recording after finishing executions

### DIFF
--- a/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
@@ -97,7 +97,10 @@ class Orchestra(
         }
 
         onFlowStart(commands)
-        return executeCommands(commands, config)
+        return executeCommands(commands, config).also {
+            // close existing screen recording, if left open.
+            screenRecording.close()
+        }
     }
 
     /**


### PR DESCRIPTION
## Proposed Changes

- Close screen recording if it was left open after finishing an execution.

## Testing
- Run a flow that triggers`startRecording` but never calls `stopRecording`.
- Verify the resulting video is not corrupted.

## Issues Fixed

https://github.com/mobile-dev-inc/maestro/issues/1177
